### PR TITLE
feat: model selection error handling

### DIFF
--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -1,6 +1,6 @@
 import { MIXPANEL_TOKEN } from "../../main";
 import { getFluxNodeTypeDarkColor } from "../../utils/color";
-import { DEFAULT_SETTINGS, SUPPORTED_MODELS, TOAST_CONFIG } from "../../utils/constants";
+import { API_KEY_LOCAL_STORAGE_KEY, DEFAULT_SETTINGS, SUPPORTED_MODELS, TOAST_CONFIG } from "../../utils/constants";
 import { Settings, FluxNodeType } from "../../utils/types";
 import { APIKeyInput } from "../utils/APIKeyInput";
 import { LabeledSelect, LabeledSlider } from "../utils/LabeledInputs";
@@ -176,7 +176,7 @@ async function checkModelAccess(model: string): Promise<boolean> {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
-        "Authorization": `Bearer ${OPENAI_API_KEY}`,
+        "Authorization": `Bearer ${API_KEY_LOCAL_STORAGE_KEY}`,
       },
     });
 

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -1,6 +1,7 @@
 import { MIXPANEL_TOKEN } from "../../main";
+import { checkModelAccess } from "../../utils/apikey";
 import { getFluxNodeTypeDarkColor } from "../../utils/color";
-import { API_KEY_LOCAL_STORAGE_KEY, DEFAULT_SETTINGS, SUPPORTED_MODELS, TOAST_CONFIG } from "../../utils/constants";
+import { DEFAULT_SETTINGS, SUPPORTED_MODELS, TOAST_CONFIG } from "../../utils/constants";
 import { Settings, FluxNodeType } from "../../utils/types";
 import { APIKeyInput } from "../utils/APIKeyInput";
 import { LabeledSelect, LabeledSlider } from "../utils/LabeledInputs";
@@ -168,30 +169,3 @@ export const SettingsModal = memo(function SettingsModal({
     </Modal>
   );
 });
-
-
-async function checkModelAccess(model: string): Promise<boolean> {
-  try {
-    const response = await fetch("https://api.openai.com/v1/models", {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${API_KEY_LOCAL_STORAGE_KEY}`,
-      },
-    });
-
-    if (response.ok) {
-      const data = await response.json();
-      const models = data.data;
-      return models.some((m: { id: string }) => m.id === model);
-    } else {
-      console.error("Error fetching models:", response.status);
-      return false;
-    }
-  } catch (error) {
-    console.error("Error fetching models:", error);
-    return false;
-  }
-}
-
-

--- a/src/utils/apikey.ts
+++ b/src/utils/apikey.ts
@@ -1,3 +1,29 @@
+import { API_KEY_LOCAL_STORAGE_KEY } from "./constants";
+
 export function isValidAPIKey(apiKey: string | null) {
   return apiKey?.length == 51 && apiKey?.startsWith("sk-");
+}
+
+export async function checkModelAccess(model: string): Promise<boolean> {
+  try {
+    const response = await fetch("https://api.openai.com/v1/models", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${API_KEY_LOCAL_STORAGE_KEY}`,
+      },
+    });
+
+    if (response.ok) {
+      const data = await response.json();
+      const models = data.data;
+      return models.some((m: { id: string }) => m.id === model);
+    } else {
+      console.error("Error fetching models:", response.status);
+      return false;
+    }
+  } catch (error) {
+    console.error("Error fetching models:", error);
+    return false;
+  }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Requested in #26 since GPT-4 nor GPT-4-32k isn't available for everyone yet and it would be a better experience to see something pop up instead of not being sure what happened.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

On model change in settings:
1. check if user has access to the model
2. if not, show error toast and provides link to waitlist (note: I don't know where the gpt-4-32k waitlist is)

## Checklist

<!--
Please ensure fill out and complete the actions below before opening your PR.
-->

- [x] Tested in Chrome
- [x] Tested in Safari


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new function `checkModelAccess` to validate access to OpenAI models and updates the `SettingsModal` component to use it when changing the selected model.

### Detailed summary
- Added `checkModelAccess` function to validate access to OpenAI models
- Updated `SettingsModal` component to use `checkModelAccess` when changing the selected model
- Added `useToast` hook to display error messages when changing to an unsupported model
- Removed unused imports and variables

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->