### PR TITLE
fix: claude branch, adds details in README to run locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ npm install
 npm run dev
 ```
 
+also, to run claude locally, you will need to [utilize this CORS proxy](https://github.com/garmeeh/local-cors-proxy).
+
+once downloaded, you can run the command `lcp --proxyUrl https://api.anthropic.com` locally before utilizing the API.
+
 ## Contributing
 
 See the [open issues](https://github.com/transmissions11/flux/issues) for a list of proposed features (and known issues).

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install
 npm run dev
 ```
 
-To run Claude branch locally, you will also need to [utilize this CORS proxy](https://github.com/garmeeh/local-cors-proxy). Once downloaded, you can run the command `lcp --proxyUrl https://api.anthropic.com` in another terminal window before using the API.
+Note: To run the `claude` branch locally, you will also need to [utilize this CORS proxy](https://github.com/garmeeh/local-cors-proxy). Once downloaded, run the command `lcp --proxyUrl https://api.anthropic.com` in another terminal window before using the API.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,7 @@ npm install
 npm run dev
 ```
 
-also, to run claude locally, you will need to [utilize this CORS proxy](https://github.com/garmeeh/local-cors-proxy).
-
-once downloaded, you can run the command `lcp --proxyUrl https://api.anthropic.com` locally before utilizing the API.
+To run Claude branch locally, you will also need to [utilize this CORS proxy](https://github.com/garmeeh/local-cors-proxy). Once downloaded, you can run the command `lcp --proxyUrl https://api.anthropic.com` in another terminal window before using the API.
 
 ## Contributing
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -373,11 +373,11 @@ function App() {
         promises.push(
           client.completeStream(
             {
-              prompt: promptFromLineage(parentNodeLineage, settings),
+              prompt: promptFromLineage(parentNodeLineage, settings, true, true), // last boolean is for isAnthropic.
               stop_sequences: [HUMAN_PROMPT],
               max_tokens_to_sample: 1000,
               model,
-              temperature: temp,
+              // temperature: temp, // ! this causes an error if used with Anthropic API for some reason.
             },
 
             {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -377,7 +377,7 @@ function App() {
               stop_sequences: [HUMAN_PROMPT],
               max_tokens_to_sample: 1000,
               model,
-              temperature: temp > 1 ? 1 : temp, // if the setting is cached above 1, Anthropic API will error out, so we force it to 1.
+              temperature: temp > 1 ? 1 : temp, // If the temp is cached above 1, Anthropic API will error out, so we force it to 1.
             },
 
             {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -373,11 +373,11 @@ function App() {
         promises.push(
           client.completeStream(
             {
-              prompt: promptFromLineage(parentNodeLineage, settings, true, true), // last boolean is for isAnthropic.
+              prompt: promptFromLineage(parentNodeLineage, settings, true, true),
               stop_sequences: [HUMAN_PROMPT],
               max_tokens_to_sample: 1000,
               model,
-              // temperature: temp, // ! this causes an error if used with Anthropic API for some reason.
+              temperature: temp > 1 ? 1 : temp, // if the setting is cached above 1, Anthropic API will error out, so we force it to 1.
             },
 
             {

--- a/src/utils/apikey.ts
+++ b/src/utils/apikey.ts
@@ -1,3 +1,4 @@
 export function isValidAPIKey(apiKey: string | null) {
-  return apiKey?.startsWith("sk-"); // remove length validation.
+  // length validation removed due to variable-length API keys.
+  return apiKey?.startsWith("sk-");
 }

--- a/src/utils/apikey.ts
+++ b/src/utils/apikey.ts
@@ -1,3 +1,3 @@
 export function isValidAPIKey(apiKey: string | null) {
-  return apiKey?.length == 89 && apiKey?.startsWith("sk-");
+  return apiKey?.startsWith("sk-"); // remove length validation.
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -15,7 +15,7 @@ export const REACT_FLOW_NODE_TYPES: Record<
   LabelUpdater: LabelUpdaterNode,
 };
 
-export const SUPPORTED_MODELS = ["claude-instant-v1", "claude-v1", "claude-v1.2", "claude-v1-100k"];
+export const SUPPORTED_MODELS = ["claude-instant-v1", "claude-v1", "claude-v1.2", "claude-v1-100k", "claude-instant-v1-100k"];
 
 export const DEFAULT_SETTINGS: Settings = {
   temp: 1.2,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -15,7 +15,7 @@ export const REACT_FLOW_NODE_TYPES: Record<
   LabelUpdater: LabelUpdaterNode,
 };
 
-export const SUPPORTED_MODELS = ["claude-instant-v1", "claude-v1", "claude-v1.2"];
+export const SUPPORTED_MODELS = ["claude-instant-v1", "claude-v1", "claude-v1.2", "claude-v1-100k"];
 
 export const DEFAULT_SETTINGS: Settings = {
   temp: 1.2,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -15,7 +15,7 @@ export const REACT_FLOW_NODE_TYPES: Record<
   LabelUpdater: LabelUpdaterNode,
 };
 
-export const SUPPORTED_MODELS = ["claude-instant-v1", "claude-v1", "claude-v1.2", "claude-v1-100k", "claude-instant-v1-100k"];
+export const SUPPORTED_MODELS = ["claude-instant-v1", "claude-v1", "claude-instant-v1-100k", "claude-v1-100k"];
 
 export const DEFAULT_SETTINGS: Settings = {
   temp: 1.2,

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -53,7 +53,8 @@ export function messagesFromLineage(
 export function promptFromLineage(
   lineage: Node<FluxNodeData>[],
   settings: Settings,
-  endWithBlankAssistant: boolean = true
+  endWithBlankAssistant: boolean = true,
+  isAnthropic: boolean = false
 ): string {
   const messages = messagesFromLineage(lineage, settings);
 
@@ -63,7 +64,12 @@ export function promptFromLineage(
     const formattedRole =
       message.role === "system" || message.role === "user" ? HUMAN_PROMPT : AI_PROMPT;
 
-    prompt += `${formattedRole} ${message.content}`;
+    if (i === 1 && isAnthropic) {
+      prompt += ` ${message.content}`;
+    }
+    else {
+      prompt += `${formattedRole} ${message.content}`;
+    }
   });
 
   if (endWithBlankAssistant) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.
-->

## Motivation

Flux would benefit greatly from a higher context window since it's a powertool that I use often for programming. Was stuck using GPT-4 until I recently got access to Claude-100k. Took some messing around to get the Claude branch working but now it's great running locally and I wanted to share my code. 

I plan to work on a way to switch between OpenAI and Claude APIs so we can get this pushed to the main branch. A Vercel Edge function looks like it can function as a CORS proxy so when I have time I can implement that (or someone else can grab it).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

The branch needed some changes to get it working with the latest version of the API. Most importantly, the System + first Human prompt need to be concatenated into one "\n\nHuman:{sequence}" since this is the correct format [according to the docs](https://console.anthropic.com/docs/troubleshooting/checklist). 

Also, if switching from a different branch, there will be an error if the previous temperature setting was above 1, due to the range being 0 to 1 for Claude. So we force this back to 1 during the API call to avoid this error.

Also added some information about the CORS proxy to the README just incase others want to run this locally

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checklist

<!--
Please ensure fill out and complete the actions below before opening your PR.
-->

- [x] Tested in Chrome
- [x] Tested in Safari
