### PR TITLE
fix: pass a reference to CopyCodeButton to prevent re-render

### DIFF
--- a/src/components/utils/Markdown.tsx
+++ b/src/components/utils/Markdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, memo, ReactNode, RefObject } from "react";
+import React, { useState, useEffect, useRef, ReactNode, RefObject } from "react";
 import ReactMarkdown, { Components } from "react-markdown";
 import "highlight.js/styles/atom-one-light.css";
 import rehypeHighlight from "rehype-highlight";
@@ -9,13 +9,13 @@ import { copySnippetToClipboard } from "../../utils/clipboard";
 import { solidity, yul } from "highlightjs-solidity";
 import { PluggableList } from "unified";
 
-const CodeblockTitleBar = memo(function CodeblockTitleBar({
+const CodeblockTitleBar = ({
   language,
   codeRef,
 }: {
   language?: string;
   codeRef: RefObject<ReactNode[]>;
-}) {
+}) => {
   // Grabbing the default font family from Chakra via
   // useTheme to override the markdown code font family.
   const theme = useTheme();
@@ -38,9 +38,9 @@ const CodeblockTitleBar = memo(function CodeblockTitleBar({
       <CopyCodeButton codeRef={codeRef} />
     </Row>
   );
-});
+};
 
-const CopyCodeButton = memo(function CopyCodeButton({ codeRef }: { codeRef: RefObject<ReactNode[]> }) {
+const CopyCodeButton = ({ codeRef }: { codeRef: RefObject<ReactNode[]> }) => {
   const [copied, setCopied] = useState(false);
 
   const handleCopyButtonClick = async (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -67,13 +67,13 @@ const CopyCodeButton = memo(function CopyCodeButton({ codeRef }: { codeRef: RefO
       <CopyIcon boxSize={4} mr={1} /> {copied ? "Copied!" : "Copy Code"}
     </Button>
   );
-});
+};
 
-const Codeblock = memo(function Codeblock({ className, inline, children, ...props }: {
+const Codeblock = ({ className, inline, children, ...props }: {
   className?: string;
   inline?: boolean;
   children: ReactNode[];
-}) {
+}) => {
   const match = /language-(\w+)/.exec(className || "");
   const codeRef = useRef<ReactNode[]>([]);
 
@@ -110,7 +110,7 @@ const Codeblock = memo(function Codeblock({ className, inline, children, ...prop
       {children}
     </Code>
   )
-});
+};
 
 const rehypePlugins: PluggableList = [
   [rehypeHighlight, { ignoreMissing: true, languages: { solidity, yul } }],
@@ -156,7 +156,7 @@ const components: Components = {
   },
 }
 
-export const Markdown = memo(function Markdown({ text }: { text: string }) {
+export const Markdown = ({ text }: { text: string }) => {
   return (
     <Box className="markdown-wrapper" width="100%" wordBreak="break-word">
       <ReactMarkdown
@@ -167,7 +167,7 @@ export const Markdown = memo(function Markdown({ text }: { text: string }) {
       </ReactMarkdown>
     </Box>
   );
-});
+};
 
 // Recursively extract text value from the children prop of a ReactMarkdown component.
 // This function is necessary because some children can contain inline elements,

--- a/src/components/utils/Markdown.tsx
+++ b/src/components/utils/Markdown.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, memo, ReactNode, RefObject } from "react";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { Components } from "react-markdown";
 import "highlight.js/styles/atom-one-light.css";
 import rehypeHighlight from "rehype-highlight";
 import { Button, Box, Code, Text, useTheme, List, ListItem } from "@chakra-ui/react";
@@ -7,6 +7,7 @@ import { CopyIcon } from "@chakra-ui/icons";
 import { Row, Column } from "../../utils/chakra";
 import { copySnippetToClipboard } from "../../utils/clipboard";
 import { solidity, yul } from "highlightjs-solidity";
+import { PluggableList } from "unified";
 
 const CodeblockTitleBar = memo(function CodeblockTitleBar({
   language,
@@ -39,7 +40,7 @@ const CodeblockTitleBar = memo(function CodeblockTitleBar({
   );
 });
 
-const CopyCodeButton = memo(function CopyCodeButton({ codeRef }: { codeRef: RefObject<ReactNode[]> }): ReactNode {
+const CopyCodeButton = memo(function CopyCodeButton({ codeRef }: { codeRef: RefObject<ReactNode[]> }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopyButtonClick = async (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -111,11 +112,11 @@ const Codeblock = memo(function Codeblock({ className, inline, children, ...prop
   )
 });
 
-const rehypePlugins = [
+const rehypePlugins: PluggableList = [
   [rehypeHighlight, { ignoreMissing: true, languages: { solidity, yul } }],
 ];
 
-const components = {
+const components: Components = {
   ul({ children }) {
     return (
       <List styleType="disc" h="fit-content">

--- a/src/components/utils/Markdown.tsx
+++ b/src/components/utils/Markdown.tsx
@@ -46,7 +46,8 @@ const CopyCodeButton = ({ codeRef }: { codeRef: RefObject<ReactNode[]> }) => {
   const handleCopyButtonClick = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation(); // Prevent this from triggering edit mode in the parent.
 
-    if (await copySnippetToClipboard(stringifyChildren(codeRef.current ?? []))) setCopied(true);
+    if (await copySnippetToClipboard(stringifyChildren(codeRef.current ?? [])))
+      setCopied(true);
   };
 
   useEffect(() => {
@@ -69,7 +70,12 @@ const CopyCodeButton = ({ codeRef }: { codeRef: RefObject<ReactNode[]> }) => {
   );
 };
 
-const Codeblock = ({ className, inline, children, ...props }: {
+const Codeblock = ({
+  className,
+  inline,
+  children,
+  ...props
+}: {
   className?: string;
   inline?: boolean;
   children: ReactNode[];
@@ -109,7 +115,17 @@ const Codeblock = ({ className, inline, children, ...props }: {
     >
       {children}
     </Code>
-  )
+  );
+};
+
+export const Markdown = ({ text }: { text: string }) => {
+  return (
+    <Box className="markdown-wrapper" width="100%" wordBreak="break-word">
+      <ReactMarkdown rehypePlugins={rehypePlugins} components={components}>
+        {text}
+      </ReactMarkdown>
+    </Box>
+  );
 };
 
 const rehypePlugins: PluggableList = [
@@ -135,8 +151,7 @@ const components: Components = {
     return (
       <ListItem as="li" mb="0px" ml="20px">
         {children?.filter(
-          (child: ReactNode) =>
-            !(typeof child === "string" && child.trim() === "")
+          (child: ReactNode) => !(typeof child === "string" && child.trim() === "")
         )}
       </ListItem>
     );
@@ -145,28 +160,14 @@ const components: Components = {
     return (
       <Box borderLeft="2px solid currentcolor" pl="20px">
         {children?.filter(
-          (child: ReactNode) =>
-            !(typeof child === "string" && child.trim() === "")
+          (child: ReactNode) => !(typeof child === "string" && child.trim() === "")
         )}
       </Box>
     );
   },
   code(props) {
-      return <Codeblock {...props} />
+    return <Codeblock {...props} />;
   },
-}
-
-export const Markdown = ({ text }: { text: string }) => {
-  return (
-    <Box className="markdown-wrapper" width="100%" wordBreak="break-word">
-      <ReactMarkdown
-        rehypePlugins={rehypePlugins}
-        components={components}
-      >
-        {text}
-      </ReactMarkdown>
-    </Box>
-  );
 };
 
 // Recursively extract text value from the children prop of a ReactMarkdown component.

--- a/src/components/utils/Markdown.tsx
+++ b/src/components/utils/Markdown.tsx
@@ -7,7 +7,6 @@ import { CopyIcon } from "@chakra-ui/icons";
 import { Row, Column } from "../../utils/chakra";
 import { copySnippetToClipboard } from "../../utils/clipboard";
 import { solidity, yul } from "highlightjs-solidity";
-import { PluggableList } from "react-markdown/lib/react-markdown";
 
 const CodeblockTitleBar = memo(function CodeblockTitleBar({
   language,
@@ -112,7 +111,7 @@ const Codeblock = memo(function Codeblock({ className, inline, children, ...prop
   )
 });
 
-const rehypePlugins: PluggableList = [
+const rehypePlugins = [
   [rehypeHighlight, { ignoreMissing: true, languages: { solidity, yul } }],
 ];
 


### PR DESCRIPTION
## Motivation

Fixes #70 

## Solution

- Use RefObject to store the children for the copy-paste button to prevent re-rendering.
- Move components and rehypePlugins to outer scope to prevent re-creation on render (useMemo could also be used, but I think this is cleaner).

## Checklist

- [x] Tested in Chrome
- [x] Tested in Safari
