### PR TITLE
feat: show available models list in settings

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -15,6 +15,7 @@ import {
   OVERLAP_RANDOMNESS_MAX,
   REACT_FLOW_NODE_TYPES,
   REACT_FLOW_LOCAL_STORAGE_KEY,
+  SUPPORTED_MODELS,
   TOAST_CONFIG,
   UNDEFINED_RESPONSE_STRING,
   STREAM_CANCELED_ERROR_MESSAGE,
@@ -864,6 +865,8 @@ function App() {
 
   const [apiKey, setApiKey] = useLocalStorage<string>(API_KEY_LOCAL_STORAGE_KEY);
 
+  const [availableModels, setAvailableModels] = useState<string[] | null>(SUPPORTED_MODELS);
+
   const isAnythingLoading = isSavingReactFlow || isSavingSettings;
 
   useBeforeunload((event: BeforeUnloadEvent) => {
@@ -1000,6 +1003,7 @@ function App() {
         onClose={onCloseSettingsModal}
         apiKey={apiKey}
         setApiKey={setApiKey}
+        availableModels={availableModels}
       />
       <Column
         mainAxisAlignment="center"

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -889,6 +889,7 @@ function App() {
         if (modelsLoadIndex !== modelsLoadCounter.current) return;
 
         if (modelList.length === 0) modelList.push(settings.model);
+
         setAvailableModels(modelList);
 
         if (!modelList.includes(settings.model)) {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -907,7 +907,7 @@ function App() {
     }
   }, [apiKey]);
 
-  const isAnythingLoading = isSavingReactFlow || isSavingSettings;
+  const isAnythingLoading = isSavingReactFlow || isSavingSettings || (availableModels === null);
 
   useBeforeunload((event: BeforeUnloadEvent) => {
     // Prevent leaving the page before saving.

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -873,6 +873,7 @@ function App() {
     if (isValidAPIKey(apiKey)) {
       const modelsLoadIndex = modelsLoadCounter.current + 1;
       modelsLoadCounter.current = modelsLoadIndex;
+
       setAvailableModels(null);
 
       (async () => {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -896,7 +896,9 @@ function App() {
         if (!modelList.includes(settings.model)) {
           const oldModel = settings.model;
           const newModel = modelList.includes(DEFAULT_SETTINGS.model) ? DEFAULT_SETTINGS.model : modelList[0];
+
           setSettings((settings) => ({ ...settings, model: newModel }));
+
           toast({
             title: `Model "${oldModel}" no longer available!`,
             description: `Switched to "${newModel}"`,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -877,7 +877,6 @@ function App() {
 
       (async () => {
         let modelList: string[] = [];
-        await new Promise((resolve) => setTimeout(resolve, 1000));
         try {
           modelList = await getAvailableChatModels(apiKey!);
         } catch (e) {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -45,6 +45,7 @@ import {
 } from "../utils/fluxNode";
 import { useLocalStorage } from "../utils/lstore";
 import { mod } from "../utils/mod";
+import { getAvailableChatModels } from "../utils/models";
 import { generateNodeId, generateStreamId } from "../utils/nodeId";
 import { messagesFromLineage, promptFromLineage } from "../utils/prompt";
 import { getQueryParam, resetURL } from "../utils/qparams";
@@ -866,6 +867,46 @@ function App() {
   const [apiKey, setApiKey] = useLocalStorage<string>(API_KEY_LOCAL_STORAGE_KEY);
 
   const [availableModels, setAvailableModels] = useState<string[] | null>(SUPPORTED_MODELS);
+  const modelsLoadCounter = useRef(0);
+
+  // Load available models for the API key.
+  useEffect(() => {
+    if (isValidAPIKey(apiKey)) {
+      const modelsLoadIndex = modelsLoadCounter.current + 1;
+      modelsLoadCounter.current = modelsLoadIndex;
+      setAvailableModels(null);
+
+      (async () => {
+        let modelList: string[] = [];
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        try {
+          modelList = await getAvailableChatModels(apiKey!);
+        } catch (e) {
+          toast({
+            title: "Failed to load model list!",
+            status: "error",
+            ...TOAST_CONFIG,
+          });
+        }
+        if (modelsLoadIndex !== modelsLoadCounter.current) return;
+
+        if (modelList.length === 0) modelList.push(settings.model);
+        setAvailableModels(modelList);
+
+        if (!modelList.includes(settings.model)) {
+          const oldModel = settings.model;
+          const newModel = modelList.includes(DEFAULT_SETTINGS.model) ? DEFAULT_SETTINGS.model : modelList[0];
+          setSettings((settings) => ({ ...settings, model: newModel }));
+          toast({
+            title: `Model "${oldModel}" no longer available!`,
+            description: `Switched to "${newModel}"`,
+            status: "warning",
+            ...TOAST_CONFIG,
+          });
+        }
+      })();
+    }
+  }, [apiKey]);
 
   const isAnythingLoading = isSavingReactFlow || isSavingSettings;
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -15,7 +15,6 @@ import {
   OVERLAP_RANDOMNESS_MAX,
   REACT_FLOW_NODE_TYPES,
   REACT_FLOW_LOCAL_STORAGE_KEY,
-  SUPPORTED_MODELS,
   TOAST_CONFIG,
   UNDEFINED_RESPONSE_STRING,
   STREAM_CANCELED_ERROR_MESSAGE,
@@ -866,7 +865,7 @@ function App() {
 
   const [apiKey, setApiKey] = useLocalStorage<string>(API_KEY_LOCAL_STORAGE_KEY);
 
-  const [availableModels, setAvailableModels] = useState<string[] | null>(SUPPORTED_MODELS);
+  const [availableModels, setAvailableModels] = useState<string[] | null>(null);
   const modelsLoadCounter = useRef(0);
 
   // Load available models for the API key.

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -866,9 +866,9 @@ function App() {
   const [apiKey, setApiKey] = useLocalStorage<string>(API_KEY_LOCAL_STORAGE_KEY);
 
   const [availableModels, setAvailableModels] = useState<string[] | null>(null);
-  const modelsLoadCounter = useRef(0);
 
-  // Load available models for the API key.
+  // modelsLoadCounter lets us discard the results of the requests if a concurrent newer one was made.
+  const modelsLoadCounter = useRef(0);
   useEffect(() => {
     if (isValidAPIKey(apiKey)) {
       const modelsLoadIndex = modelsLoadCounter.current + 1;

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -910,11 +910,12 @@ function App() {
     }
   }, [apiKey]);
 
-  const isAnythingLoading = isSavingReactFlow || isSavingSettings || (availableModels === null);
+  const isAnythingSaving = isSavingReactFlow || isSavingSettings;
+  const isAnythingLoading = isAnythingSaving || (availableModels === null);
 
   useBeforeunload((event: BeforeUnloadEvent) => {
     // Prevent leaving the page before saving.
-    if (isAnythingLoading) event.preventDefault();
+    if (isAnythingSaving) event.preventDefault();
   });
 
   /*//////////////////////////////////////////////////////////////

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -1,6 +1,6 @@
 import { MIXPANEL_TOKEN } from "../../main";
 import { getFluxNodeTypeDarkColor } from "../../utils/color";
-import { DEFAULT_SETTINGS, SUPPORTED_MODELS } from "../../utils/constants";
+import { DEFAULT_SETTINGS } from "../../utils/constants";
 import { Settings, FluxNodeType } from "../../utils/types";
 import { APIKeyInput } from "../utils/APIKeyInput";
 import { LabeledSelect, LabeledSlider } from "../utils/LabeledInputs";
@@ -26,6 +26,7 @@ export const SettingsModal = memo(function SettingsModal({
   setSettings,
   apiKey,
   setApiKey,
+  availableModels
 }: {
   isOpen: boolean;
   onClose: () => void;
@@ -33,6 +34,7 @@ export const SettingsModal = memo(function SettingsModal({
   setSettings: (settings: Settings) => void;
   apiKey: string | null;
   setApiKey: (apiKey: string) => void;
+  availableModels: string[] | null;
 }) {
   const reset = () => {
     if (
@@ -78,7 +80,7 @@ export const SettingsModal = memo(function SettingsModal({
           <LabeledSelect
             label="Model"
             value={settings.model}
-            options={SUPPORTED_MODELS}
+            options={availableModels || [settings.model]}
             setValue={(v: string) => {
               setSettings({ ...settings, model: v });
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -15,8 +15,6 @@ export const REACT_FLOW_NODE_TYPES: Record<
   LabelUpdater: LabelUpdaterNode,
 };
 
-export const SUPPORTED_MODELS = ["gpt-3.5-turbo", "gpt-4", "gpt-4-32k"];
-
 export const DEFAULT_SETTINGS: Settings = {
   temp: 1.2,
   n: 3,

--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -1,0 +1,28 @@
+export function getAvailableModels(apiKey: string): Promise<string[]> {
+    return new Promise(async (resolve, reject) => {
+        try {
+            const response = await fetch("https://api.openai.com/v1/models", {
+                method: "GET",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                },
+            })
+            const data = await response.json();
+            resolve(data.data.map((model: any) => model.id).sort());
+        } catch (err) {
+            reject(err);
+        }
+    });
+};
+
+export function getAvailableChatModels(apiKey: string): Promise<string[]> {
+    return new Promise((resolve, reject) => {
+        getAvailableModels(apiKey)
+            .then((models) => {
+                resolve(models.filter((model) => model.startsWith("gpt-")));
+            })
+            .catch((err) => {
+                reject(err);
+            });
+    });
+};


### PR DESCRIPTION
## Motivation

Currently, the list of supported models is hard-coded. That has several downsides:
- not all users / API keys have access to all hard-coded models (see https://github.com/paradigmxyz/flux/issues/26)
- not all available chat models supported, like the new `gpt-3.5-turbo-16k`
- no access to specific (older) model versions like `gpt-4-0314`

## Solution

- add a new `utils/models.ts` with a `getAvailableChatModels(apiKey)` function
- fetch available models every time the API key changes (including on app load)
- update model setting if current model no longer available
- show list of models on settings modal
- consider model list load for `isAnythingLoading`

Screenshot of an exemplary model list:
<img width="700" alt="Screenshot 2023-06-14 at 03 30 45" src="https://github.com/paradigmxyz/flux/assets/10457348/de1a59ff-6cdd-4c9f-afbf-72300ded0a0a">

## Checklist

- [x] Tested in Chrome
- [x] Tested in Safari
