### PR TITLE
Fix delete node/delete all nodes keybinds

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,7 +3,10 @@ import { isValidAPIKey } from "../utils/apikey";
 import { Column, Row } from "../utils/chakra";
 import { copySnippetToClipboard } from "../utils/clipboard";
 import { getFluxNodeTypeColor, getFluxNodeTypeDarkColor } from "../utils/color";
-import { getPlatformModifierKey, getPlatformModifierKeyText } from "../utils/platform";
+import { 
+  getPlatformModifierKeyText, 
+  getPlatformSecondaryModifierKeyText 
+} from "../utils/platform";
 import {
   API_KEY_LOCAL_STORAGE_KEY,
   DEFAULT_SETTINGS,
@@ -983,31 +986,30 @@ function App() {
                           HOTKEYS LOGIC
   //////////////////////////////////////////////////////////////*/
 
-  const modifierKey = getPlatformModifierKey();
   const modifierKeyText = getPlatformModifierKeyText();
 
-  useHotkeys(`${modifierKey}+s`, save, HOTKEY_CONFIG);
+  useHotkeys(`mod+s`, save, HOTKEY_CONFIG);
 
   useHotkeys(
-    `${modifierKey}+p`,
+    `mod+p`,
     () => newConnectedToSelectedNode(FluxNodeType.User),
     HOTKEY_CONFIG
   );
   useHotkeys(
-    `${modifierKey}+u`,
+    `mod+u`,
     () => newConnectedToSelectedNode(FluxNodeType.System),
     HOTKEY_CONFIG
   );
 
   useHotkeys(
-    `${modifierKey}+shift+p`,
+    `mod+shift+p`,
     () => newUserNodeLinkedToANewSystemNode(),
     HOTKEY_CONFIG
   );
 
-  useHotkeys(`${modifierKey}+.`, trackedAutoZoom, HOTKEY_CONFIG);
+  useHotkeys(`mod+.`, trackedAutoZoom, HOTKEY_CONFIG);
   useHotkeys(
-    `${modifierKey}+/`,
+    `mod+/`,
     () => {
       onToggleSettingsModal();
 
@@ -1015,22 +1017,22 @@ function App() {
     },
     HOTKEY_CONFIG
   );
-  useHotkeys(`${modifierKey}+shift+backspace`, onClear, HOTKEY_CONFIG);
+  useHotkeys(`mod+shift+u`, onClear, HOTKEY_CONFIG);
 
-  useHotkeys(`${modifierKey}+z`, undo, HOTKEY_CONFIG);
-  useHotkeys(`${modifierKey}+shift+z`, redo, HOTKEY_CONFIG);
+  useHotkeys(`mod+z`, undo, HOTKEY_CONFIG);
+  useHotkeys(`mod+shift+z`, redo, HOTKEY_CONFIG);
 
-  useHotkeys(`${modifierKey}+e`, showRenameInput, HOTKEY_CONFIG);
+  useHotkeys(`mod+e`, showRenameInput, HOTKEY_CONFIG);
 
-  useHotkeys(`${modifierKey}+up`, moveToParent, HOTKEY_CONFIG);
-  useHotkeys(`${modifierKey}+down`, moveToChild, HOTKEY_CONFIG);
-  useHotkeys(`${modifierKey}+left`, moveToLeftSibling, HOTKEY_CONFIG);
-  useHotkeys(`${modifierKey}+right`, moveToRightSibling, HOTKEY_CONFIG);
-  useHotkeys(`${modifierKey}+return`, () => submitPrompt(false), HOTKEY_CONFIG);
-  useHotkeys(`${modifierKey}+shift+return`, () => submitPrompt(true), HOTKEY_CONFIG);
-  useHotkeys(`${modifierKey}+k`, completeNextWords, HOTKEY_CONFIG);
-  useHotkeys(`${modifierKey}+backspace`, deleteSelectedNodes, HOTKEY_CONFIG);
-  useHotkeys(`${modifierKey}+shift+c`, copyMessagesToClipboard, HOTKEY_CONFIG);
+  useHotkeys(`mod+up`, moveToParent, HOTKEY_CONFIG);
+  useHotkeys(`mod+down`, moveToChild, HOTKEY_CONFIG);
+  useHotkeys(`mod+left`, moveToLeftSibling, HOTKEY_CONFIG);
+  useHotkeys(`mod+right`, moveToRightSibling, HOTKEY_CONFIG);
+  useHotkeys(`mod+return`, () => submitPrompt(false), HOTKEY_CONFIG);
+  useHotkeys(`mod+shift+return`, () => submitPrompt(true), HOTKEY_CONFIG);
+  useHotkeys(`mod+k`, completeNextWords, HOTKEY_CONFIG);
+  useHotkeys(`mod+d`, deleteSelectedNodes, HOTKEY_CONFIG);
+  useHotkeys(`mod+shift+c`, copyMessagesToClipboard, HOTKEY_CONFIG);
 
   /*//////////////////////////////////////////////////////////////
                               APP

--- a/src/components/utils/NavigationBar.tsx
+++ b/src/components/utils/NavigationBar.tsx
@@ -16,7 +16,10 @@ import { ChevronDownIcon } from "@chakra-ui/icons";
 
 import { Row } from "../../utils/chakra";
 import { FluxNodeType } from "../../utils/types";
-import { getPlatformModifierKeyText } from "../../utils/platform";
+import { 
+  getPlatformModifierKeyText, 
+  getPlatformSecondaryModifierKeyText 
+} from "../../utils/platform";
 
 import dave from "/dave.jpg";
 import t11s from "/t11s.jpg";
@@ -60,6 +63,7 @@ export function NavigationBar({
   onOpenSettingsModal: () => void;
 }) {
   const modifierKeyText = getPlatformModifierKeyText();
+  const secondaryKeyText = getPlatformSecondaryModifierKeyText();
 
   return (
     <Row
@@ -191,11 +195,11 @@ export function NavigationBar({
             <MenuDivider />
 
             <MenuGroup title="Delete">
-              <MenuItem command={`${modifierKeyText}⌫`} onClick={deleteSelectedNodes}>
+              <MenuItem command={`${modifierKeyText}D`} onClick={deleteSelectedNodes}>
                 Delete selected node(s)
               </MenuItem>
 
-              <MenuItem command={`⇧${modifierKeyText}⌫`} onClick={onClear}>
+              <MenuItem command={`⇧${modifierKeyText}U`} onClick={onClear}>
                 Delete everything
               </MenuItem>
             </MenuGroup>

--- a/src/components/utils/Whisper.tsx
+++ b/src/components/utils/Whisper.tsx
@@ -5,7 +5,6 @@ import mixpanel from "mixpanel-browser";
 import { MIXPANEL_TOKEN } from "../../main";
 import { useHotkeys } from "react-hotkeys-hook";
 import { HOTKEY_CONFIG } from "../../utils/constants";
-import { getPlatformModifierKey } from "../../utils/platform";
 
 export const Whisper = ({
   onConvertedText,
@@ -95,10 +94,8 @@ export const Whisper = ({
     if (MIXPANEL_TOKEN) mixpanel.track("Stopped recording");
   };
 
-  const modifierKey = getPlatformModifierKey();
-
   useHotkeys(
-    `${modifierKey}+L`,
+    `mod+L`,
     () => (isRecording ? stopRecording() : startRecording()),
     HOTKEY_CONFIG
   );

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,7 +1,7 @@
-export function getPlatformModifierKey() {
-  return window.navigator.platform === "MacIntel" ? "meta" : "ctrl";
-}
-
 export function getPlatformModifierKeyText() {
   return window.navigator.platform === "MacIntel" ? "⌘" : " Ctrl ";
+}
+
+export function getPlatformSecondaryModifierKeyText() {
+  return window.navigator.platform === "MacIntel" ? "⌥" : " Alt ";
 }


### PR DESCRIPTION
## Motivation

ctrl+backspace is used to delete entire words in all text editors. Using this bind in the website causes node deletions instead, which is bad practice.

I've changed as follows:

| Original Command                             | New Command                               | Description                          |
|----------------------------------------------|-------------------------------------------|--------------------------------------|
| <kbd>Ctrl</kbd> + <kbd>Backspace</kbd>       | <kbd>Ctrl</kbd> + <kbd>D</kbd>            | Delete current node                  |
| <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Backspace</kbd> | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>U</kbd>| Delete all nodes in the current scope|

## Solution
Commands are changed in `App.tsx` and `NavigationBar.tsx`

Also, react-hotkeys-hook has a special `mod` modifier, which listens to <kbd>Ctrl</kbd> on Windows/Linux and <kbd>Meta</kbd> on Mac, so I've removed the `getPlatformModifierKey` functions and also added a `getPlatformSecondaryModifierKeyText` for the <kbd>Alt</kbd>/<kbd>Option</kbd> text, which react-hotkeys-hook just calls `alt`.

## Checklist
- [x] Tested in Chrome
- [ ] **Tested in Safari** -- I don't have a mac to test this on, so somebody would need to check this for me. 