### PR TITLE
fix: update key validation to work with OpenAI's new project keys

### DIFF
--- a/src/utils/apikey.ts
+++ b/src/utils/apikey.ts
@@ -1,3 +1,3 @@
 export function isValidAPIKey(apiKey: string | null) {
-  return apiKey?.length == 51 && apiKey?.startsWith("sk-");
+  return (apiKey?.length === 51 && apiKey.startsWith("sk-")) || (apiKey?.length === 56 && apiKey.startsWith("sk-proj-"));
 }


### PR DESCRIPTION
fixes #97

OpenAI has introduced project keys as the new default over user keys (See: https://help.openai.com/en/articles/9186755-managing-your-work-in-the-api-platform-with-projects). This was a breaking change for those with old 'user keys', causing the validation to fail. 

Change itself was simple, consisting of 1 line at /src/utils/apikey.ts

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checklist

<!--
Please ensure fill out and complete the actions below before opening your PR.
-->

- [x] Tested in Chrome
- [x] Tested in Safari
